### PR TITLE
Smart pointers and string literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ proguard/
 *.autosave
 
 build-bluelock*
+*.pro.user*

--- a/bluelock/bluelockif.h
+++ b/bluelock/bluelockif.h
@@ -11,13 +11,13 @@ public:
     virtual int getStatus()=0;
 
     enum protocol {
-       LOCK = 1,
-       UNLOCK = 2,
-       SHUTDOWN = 3,
-       SHUTDOWN_TIME = 4,
-       NONE = 0,
-       ERROR = -1
-       };
+        NONE = 0,
+        ERROR = -1,
+        LOCK = 1,
+        UNLOCK = 2,
+        SHUTDOWN = 3,
+        SHUTDOWN_TIME = 4,
+    };
 };
 
 #endif // LOCKERIF_H

--- a/bluelock/bluelockmain.cpp
+++ b/bluelock/bluelockmain.cpp
@@ -18,5 +18,4 @@ void BluelockMain::setupServices()
 
 BluelockMain::~BluelockMain()
 {
-    delete ui;
 }

--- a/bluelock/bluelockmain.h
+++ b/bluelock/bluelockmain.h
@@ -21,7 +21,7 @@ public:
     ~BluelockMain();
 
 private:
-    Ui::BluelockMain *ui;
+    std::unique_ptr<Ui::BluelockMain> ui;
     BluelockService bluelockservice;
     LockerCoordinator lockerCoordinator;
     void setupServices();

--- a/bluelock/bluelockservice.cpp
+++ b/bluelock/bluelockservice.cpp
@@ -5,19 +5,19 @@ BluelockService::BluelockService(QObject *parent) : QObject(parent){
 
 void BluelockService::startService(){
 
-    server = new QBluetoothServer(QBluetoothServiceInfo::RfcommProtocol,this);
+    server = std::unique_ptr<QBluetoothServer>(new QBluetoothServer(QBluetoothServiceInfo::RfcommProtocol,this));
     service = server->listen(uuid,serviceName);
 
     qDebug() << "UUID: "+service.serviceUuid().toString();
     qDebug() << "Local Device: "+localDevice.name();
     qDebug() << "Address: "+localDevice.address().toString();
 
-    connect(server,SIGNAL(newConnection()),this,SLOT(acceptConnection()));
+    connect(server.get(),SIGNAL(newConnection()),this,SLOT(acceptConnection()));
 }
 
 void BluelockService::acceptConnection(){
-    socket = server->nextPendingConnection();
-    connect(socket,SIGNAL(readyRead()),this,SLOT(readNextData()));
+    socket = std::unique_ptr<QBluetoothSocket>(server->nextPendingConnection());
+    connect(socket.get(),SIGNAL(readyRead()),this,SLOT(readNextData()));
 }
 
 void BluelockService::readNextData(){
@@ -29,7 +29,5 @@ void BluelockService::readNextData(){
 
 BluelockService::~BluelockService()
 {
-    if(socket != NULL)
-        delete socket;
 }
 

--- a/bluelock/bluelockservice.h
+++ b/bluelock/bluelockservice.h
@@ -22,15 +22,15 @@ public slots:
     void readNextData();
 
 private:
-    QBluetoothSocket *socket = NULL;
-    QBluetoothServer *server;
+    std::unique_ptr<QBluetoothSocket> socket = NULL;
+    std::unique_ptr<QBluetoothServer> server;
 
     BluelockLinux ll;
     QBluetoothServiceInfo service;
     QBluetoothLocalDevice localDevice;
 
     const QBluetoothUuid uuid = QBluetoothUuid(QBluetoothUuid::HumanInterfaceDeviceService);
-    const QString serviceName = QString("BLUELOCK");
+    const QString serviceName = QStringLiteral("BLUELOCK");
 
 signals:
     void newConnection();

--- a/bluelock/main.cpp
+++ b/bluelock/main.cpp
@@ -15,16 +15,16 @@ void customMessageHandler(QtMsgType type, const QMessageLogContext& context, con
     std::cout << message.toStdString() << std::endl;
     switch (type) {
     case QtDebugMsg:
-        txt = QString("Debug - %1: %2").arg(time.currentTime().toString()).arg(message);
+        txt = QStringLiteral("Debug - %1: %2").arg(time.currentTime().toString()).arg(message);
         break;
     case QtWarningMsg:
-        txt = QString("Warning - %1: %2").arg(time.currentTime().toString()).arg(message);
+        txt = QStringLiteral("Warning - %1: %2").arg(time.currentTime().toString()).arg(message);
         break;
     case QtCriticalMsg:
-        txt = QString("Critical - %1: %2").arg(time.currentTime().toString()).arg(message);
+        txt = QStringLiteral("Critical - %1: %2").arg(time.currentTime().toString()).arg(message);
         break;
     case QtFatalMsg:
-        txt = QString("Fatal - %1: %2").arg(time.currentTime().toString()).arg(message);
+        txt = QStringLiteral("Fatal - %1: %2").arg(time.currentTime().toString()).arg(message);
         abort();
     }
     QFile outFile("bluelock_log");


### PR DESCRIPTION
Changes:
- Use smart pointers whereever possible
- Use QStringLiteral macro to create QStrings from literals. This is faster than calling QString.
